### PR TITLE
RWA-5132 Fix brace-expansion CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "cookie": "^1.0.0",
     "cross-spawn": "7.0.6",
     "undici": "8.3.0",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "jws": "4.0.1",
     "superagent": "^10.2.2",
     "@opentelemetry/sdk-node": "^0.218.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5205,12 +5205,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### JIRA link ###

https://tools.hmcts.net/jira/browse/RWA-5132

### Change description ###

Updates the brace-expansion resolution from 5.0.8 to 5.0.9 to remediate GHSA-rgw5-rvv9-x895 / CVE-2026-14257 reported by `yarn npm audit --recursive --environment production`.

Verification:
- `yarn install --immutable` passed
- `yarn lint` passed
- `yarn test` passed
- `yarn build` passed
- `yarn test:dependencies` passed
- `env ALLOW_CONFIG_MUTATIONS=true yarn test:routes` passed
- `yarn npm audit --recursive --environment production` no longer reports brace-expansion

Remaining audit output:
- `otplib@12.0.1` deprecation advisories remain because remediation requires a major upgrade to v13, outside this CVE patch/minor scope.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```